### PR TITLE
Reproducing video.js 7 + mux data error when closing player

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { navigate } from 'gatsby';
 import Player from '../components/player';
 
 export default function Home() {
@@ -11,6 +12,7 @@ export default function Home() {
       <div style={{marginTop: '40px'}}>
         <button onClick={() => setIsMounted(true)}>Mount</button>
         <button onClick={() => setIsMounted(false)}>Dispose</button>
+        <button onClick={() => navigate('/two')}>Navigate to Page Two</button>
       </div>
     </div>
   )

--- a/src/pages/two.js
+++ b/src/pages/two.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { navigate } from 'gatsby';
+
+const Two = () => {
+  return (
+    <>
+      <h2>Page Two</h2>
+      <button onClick={() => navigate('/')}>Go Back</button>
+    </>
+  );
+}
+
+export default Two;


### PR DESCRIPTION
This error is intermittent but happens the majority of the time I load the player. It appears that interacting with the player, mainly scrubbing forward triggers this. 

My environment: 

**Browser:** Version 86.0.4240.111 (Official Build) (x86_64)
**OS:** macOS Catalina 10.15.5

Steps to Reproduce:

1. Click the "Mount" button
2. Play the video
3. Click on the progress bar to scrub forward
4. Let the video continue to play from it's new position for a few seconds
5. Click the "Navigate to Page Two" button
6. Observe error in developer console

```
[mux] A monitor for `vjs_video_4513` has not been initialized. 
    at HotExportedHome (eval at ES6ProxyComponentFactory (http://localhost:8001/commons.js:1:1), <anonymous>:14:7)
    at PageRenderer (eval at ES6ProxyComponentFactory (http://localhost:8001/commons.js:1:1), <anonymous>:14:7)
    at PageQueryStore (eval at ES6ProxyComponentFactory (http://localhost:8001/commons.js:1:1), <anonymous>:14:7)
    at RouteHandler
    at div
```